### PR TITLE
Allow for the use of a pre-existing identitystore group

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # Outputs placeholder
 output "group_id" {
   description = "the ID of the identity store group"
-  value       = aws_identitystore_group.this.group_id
+  value       = var.create_group ? aws_identitystore_group.this[0].group_id : data.aws_identitystore_group.this[0].group_id
 }
 
 output "permission_set_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,9 @@ variable "accounts" {
 }
 
 variable "create_group" {
-  description = "Whether to create a new usergroup. Defaults to false"
+  description = "Whether to create a new usergroup. Defaults to true so that updates don't cause issues"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "group_description" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "accounts" {
   type        = list(string)
 }
 
+variable "create_group" {
+  description = "Whether to create a new usergroup. Defaults to false"
+  type        = bool
+  default     = false
+}
+
 variable "group_description" {
   description = "Description of the user group"
   type        = string
@@ -52,4 +58,5 @@ variable "policy_inline" {
 variable "users" {
   description = "List of users to add to group"
   type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
👋 
This PR allows the use of a pre-existing identitystore group (such as one created from an external IdP via SCIM)

This also makes users not a required variable anymore, so I set a default empty map there