### PR TITLE
Add session duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ No modules.
 | policy\_customer\_managed\_name | Name of the policy to attach to permission set | `string` | `""` | no |
 | policy\_customer\_managed\_path | Path of the policy to attach to permission set | `string` | `"/"` | no |
 | policy\_inline | Inline policy in JSON format to attach to permission set | `string` | `""` | no |
+| session\_duration | The user session duration in ISO-8601 format | `string` | `"PT1H"` | no |
 | users | List of users to add to group | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -26,9 +26,10 @@ resource "aws_identitystore_group" "this" {
 
 # Permission set
 resource "aws_ssoadmin_permission_set" "this" {
-  name         = var.permission_set_name
-  description  = var.permission_set_description
-  instance_arn = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  name             = var.permission_set_name
+  description      = var.permission_set_description
+  instance_arn     = tolist(data.aws_ssoadmin_instances.this.arns)[0]
+  session_duration = var.session_duration
 }
 
 # AWS-managed policy attachments

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,9 @@ variable "users" {
   type        = map(string)
   default     = {}
 }
+
+variable "session_duration" {
+  description = "The user session duration in ISO-8601 format"
+  type        = string
+  default     = "PT1H"
+}


### PR DESCRIPTION
Fixes https://github.com/trussworks/terraform-aws-sso-group/issues/13

Changes proposed in this pull request:

- Adds variable `session_duration` to make user session duration configurable
